### PR TITLE
Add '.call' as alias for '.run'

### DIFF
--- a/lib/actionable/action.rb
+++ b/lib/actionable/action.rb
@@ -25,6 +25,8 @@ module Actionable
         instance.result
       end
 
+      alias_method :call, :run
+
       private
 
       def run_with_transaction(instance, &blk)

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -6,6 +6,7 @@ module Actionable
     context 'class' do
       it { expect(klass.model).to eq Invoice }
       it { expect(klass.actions).to eq %i{ fail_for_2 add_one add_two } }
+      it { expect(klass.method(:call)).to eq klass.method(:run) }
     end
     context 'result' do
       subject { klass.run number }


### PR DESCRIPTION
With the ability to use '.call' as an alias for '.run' actionable actions can be
chained together as steps in a 'Dry::Transaction' process.  Dry::Transaction
requires that individual steps respond to '.call' similar to Procs/Lambdas.
This allows for us to treat an actionable object as another function in a
transaction chain.

---

More Detail

Actionable is great for imperative work with shared state, 'do these commands against this initialized data/external db', whereas Dry::Transaction is great at glueing together commands that act like pure functions, value in/value out, piping values through the series.  I have created a custom step adapter for Dry::Transaction within our app that will treat an actionable file as another function allowing us to mix Actionable files for state mutation and purer functions for data processing/business rules.  The one hold up is that I have to alias 'call' to 'run' in every actionable file because Dry::Transaction does an initial check to make sure that 'call' exists.

This alias would also make it easy to stub Actionable class dependencies with a simple Lambda or Proc in testing.