### PR TITLE
Allow steps to properly stay unique in a Set

### DIFF
--- a/lib/actionable/steps/base.rb
+++ b/lib/actionable/steps/base.rb
@@ -18,6 +18,18 @@ module Actionable
 
       alias inspect to_s
 
+      # redefine equality using #eql? and #hash to get valid uniqueness checks
+      def eql?(other)
+        self.class == other.class && self.name == other.name
+      end
+
+      alias == eql?
+      alias equal? eql?
+
+      def hash
+        [self.class.name, self.name].hash
+      end
+
       private
 
       def skip?(instance)

--- a/lib/actionable/version.rb
+++ b/lib/actionable/version.rb
@@ -1,3 +1,3 @@
 module Actionable
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -9,6 +9,16 @@ module Actionable
       it { expect(klass.steps.map(&:name)).to eq %w[fail_for_2 add_one add_two] }
       it { expect(klass.method(:call)).to eq klass.method(:run) }
       it { expect(klass.action_name).to eq 'test_actionable/great_action' }
+
+      context 'with a step added more than once' do
+        before do
+          10.times do
+            klass.step(:fail_for_2)
+          end
+        end
+
+        it { expect(klass.steps.map(&:name)).to eq %w[fail_for_2 add_one add_two] }
+      end
     end
     context 'result' do
       let(:klass) { TestActionable::GreatAction }

--- a/spec/steps/method_spec.rb
+++ b/spec/steps/method_spec.rb
@@ -15,6 +15,47 @@ module Actionable
           subject.run instance
         end
       end
+
+      describe 'equality' do
+        context 'unmatched names' do
+          let(:method_one) { described_class.new 'one' }
+          let(:method_two) { described_class.new 'two' }
+
+          it 'should not be equal' do
+            expect(method_one).to_not eq method_two
+          end
+
+          it 'should not collide in a Set' do
+            expect(Set.new([method_one, method_two]).length).to eq 2
+          end
+        end
+
+        context 'unmatched classes' do
+          let(:method_one) { described_class.new 'one' }
+          let(:method_two) { Actionable::Steps::Case.new('one', {}) {} }
+
+          it 'should not be equal' do
+            expect(method_one).to_not eq method_two
+          end
+
+          it 'should not collide in a Set' do
+            expect(Set.new([method_one, method_two]).length).to eq 2
+          end
+        end
+
+        context 'matching class and name' do
+          let(:method_one) { described_class.new 'one' }
+          let(:method_two) { described_class.new 'one' }
+
+          it 'should be equal' do
+            expect(method_one).to eq method_two
+          end
+
+          it 'should collide in a Set' do
+            expect(Set.new([method_one, method_two]).length).to eq 1
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When an Actionable action is loaded in Sidekiq, the class may be loaded more than once.

When any Actionable class is reloaded, any `step` call will be executed a second time.

Actionable uses a Set to prevent duplication in this case, but the effect was meaningless, as object equality on Steps was not based on the name, but on the object id.

This patch allows Step objects to be properly checked for uniqueness in a Set.