### PR TITLE
add overridable default transaction option

### DIFF
--- a/lib/actionable/action.rb
+++ b/lib/actionable/action.rb
@@ -64,6 +64,18 @@ module Actionable
 
       alias transactional_model model
 
+      def default_transaction_options
+        { requires_new: true }
+      end
+
+      def set_transaction_options(options = {})
+        @transaction_options = default_transaction_options.merge(options)
+      end
+
+      def transaction_options
+        @transaction_options ? @transaction_options : default_transaction_options
+      end
+
       def measure(value = :nil)
         @measure = value.to_sym unless value == :nil
         @measure || :none
@@ -71,6 +83,7 @@ module Actionable
 
       def inherited(subclass)
         subclass.set_model @model_name if @model_name
+        subclass.set_transaction_options @transaction_options if @transaction_options
         subclass.action_logger @action_logger if @action_logger
         subclass.action_logger_severity @action_logger_severity if @action_logger_severity
       end

--- a/lib/actionable/action.rb
+++ b/lib/actionable/action.rb
@@ -56,11 +56,6 @@ module Actionable
         @model_name = name.to_sym
       end
 
-      def set_safely_nesting_transactional_model(name = :nothing)
-        set_model(name)
-        set_transaction_options({ requires_new: true })
-      end
-
       alias set_transactional_model set_model
 
       def model
@@ -68,6 +63,11 @@ module Actionable
       end
 
       alias transactional_model model
+
+      def set_safely_nesting_transactional_model(name = :nothing)
+        set_model(name)
+        set_transaction_options({ requires_new: true })
+      end
 
       def set_transaction_options(options = {})
         @transaction_options = (@transaction_options || {}).merge(options)

--- a/lib/actionable/action.rb
+++ b/lib/actionable/action.rb
@@ -56,6 +56,11 @@ module Actionable
         @model_name = name.to_sym
       end
 
+      def set_safely_nesting_transactional_model(name = :nothing)
+        set_model(name)
+        set_transaction_options({ requires_new: true })
+      end
+
       alias set_transactional_model set_model
 
       def model
@@ -64,16 +69,12 @@ module Actionable
 
       alias transactional_model model
 
-      def default_transaction_options
-        { requires_new: true }
-      end
-
       def set_transaction_options(options = {})
-        @transaction_options = default_transaction_options.merge(options)
+        @transaction_options = (@transaction_options || {}).merge(options)
       end
 
       def transaction_options
-        @transaction_options ? @transaction_options : default_transaction_options
+        @transaction_options ? @transaction_options : {}
       end
 
       def measure(value = :nil)

--- a/lib/actionable/action_runner.rb
+++ b/lib/actionable/action_runner.rb
@@ -24,7 +24,7 @@ module Actionable
     private
 
     def run_with_transaction(&blk)
-      @klass.model.transaction { run_without_transaction(&blk) }
+      @klass.model.transaction(@klass.transaction_options) { run_without_transaction(&blk) }
     end
 
     def run_without_transaction(&blk)

--- a/lib/actionable/version.rb
+++ b/lib/actionable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Actionable
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -51,6 +51,7 @@ module Actionable
         end
         it do
           msg = nil
+          expect(Invoice).to receive(:transaction).with(requires_new: true).and_call_original
           klass.run(number) { |x| msg = x.message }
           expect(msg).to eq 'Completed successfully.'
         end
@@ -297,6 +298,15 @@ module Actionable
           end
           it { subject }
         end
+      end
+    end
+    context "disable default transaction options" do
+      let(:klass) { TestActionable::DisableDefaultTransactionOptions }
+      let(:number) { 1 }
+      subject { klass.run number }
+      it "calls transaction with requires_new: false" do
+        expect(Invoice).to receive(:transaction).with(requires_new: false).and_call_original
+        subject
       end
     end
   end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -51,7 +51,7 @@ module Actionable
         end
         it do
           msg = nil
-          expect(Invoice).to receive(:transaction).with(requires_new: true).and_call_original
+          expect(Invoice).to receive(:transaction).with({}).and_call_original
           klass.run(number) { |x| msg = x.message }
           expect(msg).to eq 'Completed successfully.'
         end
@@ -300,12 +300,21 @@ module Actionable
         end
       end
     end
-    context "disable default transaction options" do
-      let(:klass) { TestActionable::DisableDefaultTransactionOptions }
+    context "set explicit transaction options" do
+      let(:klass) { TestActionable::ExplicitTransactionOptions }
       let(:number) { 1 }
       subject { klass.run number }
-      it "calls transaction with requires_new: false" do
-        expect(Invoice).to receive(:transaction).with(requires_new: false).and_call_original
+      it "calls transaction with requires_new: true" do
+        expect(Invoice).to receive(:transaction).with(requires_new: true).and_call_original
+        subject
+      end
+    end
+    context "with set_safely_nesting_transactional_model" do
+      let(:klass) { TestActionable::ExplicitTransactionOptions }
+      let(:number) { 1 }
+      subject { klass.run number }
+      it "calls transaction with requires_new: true" do
+        expect(Invoice).to receive(:transaction).with(requires_new: true).and_call_original
         subject
       end
     end

--- a/spec/support/actionable.rb
+++ b/spec/support/actionable.rb
@@ -81,6 +81,11 @@ module TestActionable
     step :add_two
   end
 
+  class DisableDefaultTransactionOptions < BaseAction
+    set_transaction_options(requires_new: false)
+    action :add_ten
+  end
+
   class AddTwo < BaseAction
     step :add_two
   end

--- a/spec/support/actionable.rb
+++ b/spec/support/actionable.rb
@@ -81,9 +81,14 @@ module TestActionable
     step :add_two
   end
 
-  class DisableDefaultTransactionOptions < BaseAction
-    set_transaction_options(requires_new: false)
+  class ExplicitTransactionOptions < BaseAction
+    set_transaction_options(requires_new: true)
     action :add_ten
+  end
+
+  class SafeNestingTransaction < BaseAction
+    set_safely_nesting_transactional_model :invoice
+    action :add_three
   end
 
   class AddTwo < BaseAction


### PR DESCRIPTION
When actionable classes get used heavily in a code base, they frequently get called from other actionable classes. This can lead to unexpected database behaviors if those actionable classes use `set_model` to wrap the actionable actions in database transactions. Nested database transactions can rollback changes in unexpected ways. See explanation here... https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions

The recommended way to handle nested transactions (if they can't be avoided) is to use the option `requires_new: true`. In this PR I've updated actionable to add the `requires_new: true` argument to all database transactions by default. It is possible to override the default if there is a reason to, but I thought it would make sense to have the option be opt-out instead of opt-in.