### PR TITLE
Fix rescue bug

### DIFF
--- a/lib/actionable/action_runner.rb
+++ b/lib/actionable/action_runner.rb
@@ -46,13 +46,14 @@ module Actionable
       code, res = step.run @instance
     rescue SkippableError
       code = :skippable_error
-    rescue StandardError => e
+      # it's bad practice to rescue Exception, but it's preferable in this case because it will be raised in the ensure
+    rescue Exception => e
       exc = e
       code = :exception
     ensure
       measure section, step, :stop, code, res
       raise exc if exc
-
+      # this return will swallow Exceptions unless they are explicitly raised in the ensure block
       return res
     end
 

--- a/lib/actionable/action_runner.rb
+++ b/lib/actionable/action_runner.rb
@@ -46,7 +46,7 @@ module Actionable
       code, res = step.run @instance
     rescue SkippableError
       code = :skippable_error
-      # it's bad practice to rescue Exception, but it's preferable in this case because it will be raised in the ensure
+    # it's bad practice to rescue Exception, but it's preferable in this case because it will be raised in the ensure
     rescue Exception => e
       exc = e
       code = :exception


### PR DESCRIPTION
While updating the version of Actionable in MP, the test suite encountered a lot of failures for a specific reason. After digging into the issue, it turns out that the measurement changes to actionable introduced a bug that caused some exceptions to get swallowed. 

Specifically, exceptions that don't inherit from `StandardError` effectively disappear because they are not raised in the `ensure` block. Since they aren't rescued and explicitly raised in the `ensure` block and the `ensure` block explicitly returns a result, then nothing is done with the `Exception`, effectively making it disappear.

This was discovered by MP specs that raised `Exception` in the first actionable step. The actionable tests should have failed on the first step, but instead broke on subsequent steps. This was because the exceptions were disappearing and the actionable was progressing to steps that shouldn't have executed because of the exception thrown in the first step.