### PR TITLE
Increase the top end of the took-e check

### DIFF
--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -45,7 +45,7 @@ module Actionable
           it('[name3]') { expect(subject.history['add_two']).to be_a Actionable::History::Step }
           it('[name4]') { expect(subject.history[:unknown]).to eq nil }
           it('time   ') { expect(subject.history.map { |x| x.start_time.to_s[0, 19] }.uniq).to eq([Time.now.to_s[0, 19]]) }
-          it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0002 }).to eq true }
+          it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0004 }).to eq true }
           it('took   ') { expect(subject.history.took).to be > 0 }
           it('code   ') { expect(subject.history.map(&:code)).to eq(%i[na na na]) }
           it('history') { expect(subject.history.map(&:history)).to eq([nil, nil, nil]) }
@@ -76,7 +76,7 @@ module Actionable
           it('section') { expect(subject.history.map(&:section)).to eq(%i[main]) }
           it('name   ') { expect(subject.history.map(&:name)).to eq(['fail_for_2']) }
           it('time   ') { expect(subject.history.map { |x| x.start_time.to_s[0, 19] }.uniq).to eq([Time.now.to_s[0, 19]]) }
-          it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0002 }).to eq true }
+          it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0004 }).to eq true }
           it('took   ') { expect(subject.history.took).to be > 0 }
           it('code   ') { expect(subject.history.map(&:code)).to eq([:bad_number]) }
           it('history') { expect(subject.history.map(&:history)).to eq([nil]) }
@@ -104,7 +104,7 @@ module Actionable
               it('section') { expect(subject.history.map(&:section)).to eq(%i[main main]) }
               it('name   ') { expect(subject.history.map(&:name)).to eq(%w[test_actionable/small_action add_five]) }
               it('time   ') { expect(subject.history.map { |x| x.start_time.to_s[0, 19] }.uniq).to eq([Time.now.to_s[0, 19]]) }
-              it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0002 }).to eq true }
+              it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0004 }).to eq true }
               it('took   ') { expect(subject.history.took).to be > 0 }
               it('code   ') { expect(subject.history.map(&:code)).to eq(%i[success na]) }
               context 'nested' do
@@ -136,7 +136,7 @@ module Actionable
               it('section') { expect(subject.history.map(&:section)).to eq(%i[main]) }
               it('name   ') { expect(subject.history.map(&:name)).to eq(%w[test_actionable/small_action]) }
               it('time   ') { expect(subject.history.map { |x| x.start_time.to_s[0, 19] }.uniq).to eq([Time.now.to_s[0, 19]]) }
-              it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0002 }).to eq true }
+              it('took-e ') { expect(subject.history.map(&:took).all? { |x| x > 0.0 && x < 0.0004 }).to eq true }
               it('took   ') { expect(subject.history.took).to be > 0 }
               it('code   ') { expect(subject.history.map(&:code)).to eq([:fail]) }
               context 'nested' do


### PR DESCRIPTION
This commit ups the top end of the took-e range check, in order to make the build less fragile.

Prior to the change, the build failed 4/10 times (locally)
After this change, the build succeeds on all 10 runs locally.

@aemadrid : I was told to tag you in this change, hopefully, you can provide some insight if 0.0002 is a set number for a reason or just an arbitrary number at the time. 
