### PR TITLE
Bump gem version

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish gem
-        uses: jstastny/publish-gem-to-github@v2.1
+        uses: jstastny/publish-gem-to-github@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: acima-credit

--- a/lib/actionable/version.rb
+++ b/lib/actionable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Actionable
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
This PR -> https://github.com/acima-credit/actionable/pull/18 had a code change but the version wasn't bumped.  That resulted in the package not getting published properly.  If the PR changes code then you must bump the gem version.